### PR TITLE
Adding --dump-input flag 

### DIFF
--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -154,7 +154,7 @@ def list_installed_templates(default_config, passed_config_file):
 @click.option(
     '--dump-input',
     is_flag=True,
-    help="Add user input to generated .cookiecutter.json"
+    help="Add user input to generated .cookiecutter.json",
 )
 def main(
     template,
@@ -174,7 +174,7 @@ def main(
     replay_file,
     list_installed,
     keep_project_on_failure,
-    dump_input
+    dump_input,
 ):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
@@ -220,7 +220,7 @@ def main(
             skip_if_file_exists=skip_if_file_exists,
             accept_hooks=_accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
-            dump_input=dump_input
+            dump_input=dump_input,
         )
     except (
         ContextDecodingException,

--- a/cookiecutter/cli.py
+++ b/cookiecutter/cli.py
@@ -151,6 +151,11 @@ def list_installed_templates(default_config, passed_config_file):
     is_flag=True,
     help='Do not delete project folder on failure',
 )
+@click.option(
+    '--dump-input',
+    is_flag=True,
+    help="Add user input to generated .cookiecutter.json"
+)
 def main(
     template,
     extra_context,
@@ -169,6 +174,7 @@ def main(
     replay_file,
     list_installed,
     keep_project_on_failure,
+    dump_input
 ):
     """Create a project from a Cookiecutter project template (TEMPLATE).
 
@@ -214,6 +220,7 @@ def main(
             skip_if_file_exists=skip_if_file_exists,
             accept_hooks=_accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
+            dump_input=dump_input
         )
     except (
         ContextDecodingException,

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -277,6 +277,7 @@ def generate_files(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
+    dump_input=False
 ):
     """Render the templates and saves them to files.
 
@@ -290,6 +291,8 @@ def generate_files(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
+    :param dump_input: If 'True' the user input will be added to the generated template in a new file named:
+        '.cookiecutter.json'
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from %s...', template_dir)
@@ -321,6 +324,12 @@ def generate_files(
     # if we created the output directory, then it's ok to remove it
     # if rendering fails
     delete_project_on_failure = output_directory_created and not keep_project_on_failure
+
+    # Add user input if required
+    if dump_input:
+        user_input_file_path = os.path.join(project_dir, '.cookiecutter.json')
+        with open(user_input_file_path, 'w') as user_input_file:
+            json.dump(context['cookiecutter'], user_input_file, indent=2)
 
     if accept_hooks:
         _run_hook_from_repo_dir(

--- a/cookiecutter/generate.py
+++ b/cookiecutter/generate.py
@@ -277,7 +277,7 @@ def generate_files(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
-    dump_input=False
+    dump_input=False,
 ):
     """Render the templates and saves them to files.
 
@@ -291,8 +291,8 @@ def generate_files(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
-    :param dump_input: If 'True' the user input will be added to the generated template in a new file named:
-        '.cookiecutter.json'
+    :param dump_input: If 'True' the user input will be added to the generated
+        template in a new file named: '.cookiecutter.json'
     """
     template_dir = find_template(repo_dir)
     logger.debug('Generating project from %s...', template_dir)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -35,6 +35,7 @@ def cookiecutter(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
+    dump_input=False
 ):
     """
     Run Cookiecutter just as if using it from the command line.
@@ -58,6 +59,7 @@ def cookiecutter(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
+    :param dump_input: If 'True' the user input will be saved in new created file named .cookiecutter.json
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -127,6 +129,7 @@ def cookiecutter(
             output_dir=output_dir,
             accept_hooks=accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
+            dump_input=dump_input
         )
 
     # Cleanup (if required)

--- a/cookiecutter/main.py
+++ b/cookiecutter/main.py
@@ -35,7 +35,7 @@ def cookiecutter(
     skip_if_file_exists=False,
     accept_hooks=True,
     keep_project_on_failure=False,
-    dump_input=False
+    dump_input=False,
 ):
     """
     Run Cookiecutter just as if using it from the command line.
@@ -59,7 +59,8 @@ def cookiecutter(
     :param accept_hooks: Accept pre and post hooks if set to `True`.
     :param keep_project_on_failure: If `True` keep generated project directory even when
         generation fails
-    :param dump_input: If 'True' the user input will be saved in new created file named .cookiecutter.json
+    :param dump_input: If 'True' the user input will be saved in
+        new created file named .cookiecutter.json
     """
     if replay and ((no_input is not False) or (extra_context is not None)):
         err_msg = (
@@ -129,7 +130,7 @@ def cookiecutter(
             output_dir=output_dir,
             accept_hooks=accept_hooks,
             keep_project_on_failure=keep_project_on_failure,
-            dump_input=dump_input
+            dump_input=dump_input,
         )
 
     # Cleanup (if required)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -110,6 +110,7 @@ def test_cli_replay(mocker, cli_runner):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -137,6 +138,7 @@ def test_cli_replay_file(mocker, cli_runner):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -173,6 +175,7 @@ def test_cli_exit_on_noinput_and_replay(mocker, cli_runner):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -209,6 +212,7 @@ def test_run_cookiecutter_on_overwrite_if_exists_and_replay(
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -266,6 +270,7 @@ def test_cli_output_dir(mocker, cli_runner, output_dir_flag, output_dir):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -311,6 +316,7 @@ def test_user_config(mocker, cli_runner, user_config_path):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -342,6 +348,40 @@ def test_default_user_config_overwrite(mocker, cli_runner, user_config_path):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
+    )
+
+
+def test_user_input_dump(mocker, cli_runner, user_config_path):
+    """Test cli invocation calls with --dump-input flag."""
+    mock_cookiecutter = mocker.patch('cookiecutter.cli.cookiecutter')
+
+    template_path = 'tests/fake-repo-pre/'
+    result = cli_runner(
+        template_path,
+        '--config-file',
+        user_config_path,
+        '--dump-input',
+    )
+
+    assert result.exit_code == 0
+    mock_cookiecutter.assert_called_once_with(
+        template_path,
+        None,
+        False,
+        replay=False,
+        overwrite_if_exists=False,
+        skip_if_file_exists=False,
+        output_dir='.',
+        config_file=user_config_path,
+        default_config=False
+        ,
+        extra_context=None,
+        password=None,
+        directory=None,
+        accept_hooks=True,
+        keep_project_on_failure=False,
+        dump_input=True,
     )
 
 
@@ -368,6 +408,7 @@ def test_default_user_config(mocker, cli_runner):
         directory=None,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -633,6 +674,7 @@ def test_cli_accept_hooks(
         skip_if_file_exists=False,
         accept_hooks=expected,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -374,8 +374,7 @@ def test_user_input_dump(mocker, cli_runner, user_config_path):
         skip_if_file_exists=False,
         output_dir='.',
         config_file=user_config_path,
-        default_config=False
-        ,
+        default_config=False,
         extra_context=None,
         password=None,
         directory=None,

--- a/tests/test_generate_files.py
+++ b/tests/test_generate_files.py
@@ -260,6 +260,25 @@ def test_generate_files_with_overwrite_if_exists_with_skip_if_file_exists(tmp_pa
     assert simple_text == 'temp'
 
 
+def test_generate_files_with_user_output(tmp_path):
+    """Verify that user input file is generated when `dump_input` option is on."""
+    user_input_file_path = Path(tmp_path, 'inputpizzä', '.cookiecutter.json')
+
+    generate.generate_files(
+        context={'cookiecutter': {'food': 'pizzä'}},
+        repo_dir='tests/test-generate-files',
+        output_dir=tmp_path,
+        dump_input=True,
+    )
+
+    assert Path(user_input_file_path).is_file()
+    assert Path(user_input_file_path).exists()
+
+    # Using the unicode_scape because of the special ä character
+    simple_text = Path(user_input_file_path).read_text(encoding='unicode_escape')
+    assert simple_text == '{\n  "food": "pizzä"\n}'
+
+
 def test_generate_files_with_skip_if_file_exists(tmp_path):
     """Verify existed files not removed if error raised with `skip_if_file_exists`."""
     simple_file = Path(tmp_path, 'inputpizzä/simple.txt')

--- a/tests/test_specify_output_dir.py
+++ b/tests/test_specify_output_dir.py
@@ -58,6 +58,7 @@ def test_api_invocation(mocker, template, output_dir, context):
         output_dir=output_dir,
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )
 
 
@@ -75,4 +76,5 @@ def test_default_output_dir(mocker, template, context):
         output_dir='.',
         accept_hooks=True,
         keep_project_on_failure=False,
+        dump_input=False,
     )


### PR DESCRIPTION
When the flag is added, the user input will be writen to the created project template in a new file named: .cookiecutter.json